### PR TITLE
Bugfix arraylength

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -44,10 +44,6 @@ tv.prototype.calculateChecksum = function(array) {
  * @param   function  callback
  */
 tv.prototype.send = function(array, callback) {
-  if (array.length != 6) {
-    callback(new Error('Array must be 6 long'));
-    return;
-  }
 
   array.push('0x' + this.calculateChecksum(array));
 


### PR DESCRIPTION
according to the official documentation, newer TVs have 5 bytes, the sixth byte is the (generated) checksum.

`Header | Command | ID | Data | Length | Check Sum`