### PR TITLE
samsung-tv 0.3.0

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -34,7 +34,7 @@ tv.prototype.calculateChecksum = function(array) {
     sum+= element;
   });
 
-  return (256 - sum).toString(16);
+  return (sum).toString(16).slice(-2);
 }
 
 /**

--- a/lib/app.js
+++ b/lib/app.js
@@ -44,10 +44,6 @@ tv.prototype.calculateChecksum = function(array) {
  * @param   function  callback
  */
 tv.prototype.send = function(array, callback) {
-  if (array.length != 6) {
-    callback(new Error('Array must be 6 long'));
-    return;
-  }
 
   array.push('0x' + this.calculateChecksum(array));
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "samsung-tv",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Module for controlling Samsung TVs via RS232",
-  "main": "./lib/apc.js",
+  "main": "./lib/app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- use the latest stable version of serialport (4.0.3)
- catch uncaught error
- fixed serialport implementation
- fixed checksum calculation
- remove array length restriction