### PR TITLE
samsung-tv 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "samsung-tv",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Module for controlling Samsung TVs via RS232",
-  "main": "./lib/apc.js",
+  "main": "./lib/app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- use the latest stable version of serialport (4.0.3)
- catch uncaught error
- fixed serialport implementation
- fixed checksum calculation
- remove array length restriction
